### PR TITLE
fix: return response of the /me method

### DIFF
--- a/docs/market_api.markdown
+++ b/docs/market_api.markdown
@@ -871,10 +871,12 @@ Response:
                 "balance": (int),
                 "hold": (int),
                 ...
-                "system_info": {
-                    "visitor_id": (int),
-                    "time": (unix timestamp in seconds)
-                ...
+            }
+            "isIsolatedMarket": (boolean),
+            "isIsolatedMarketAlt": (boolean),
+            "system_info": {
+                 "visitor_id": (int),
+                 "time": (unix timestamp in seconds)
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Fixed the example of the returned response body using the `/me` method in the market API.

![image](https://github.com/NztForum/Lolzteam-Public-API/assets/33278849/eb808ee2-6af3-49b5-b800-9b96fbe3fd93)
